### PR TITLE
Rename Cookbook

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,29 +1,30 @@
+# rubocop:disable LineLength
 #
-# Cookbook Name:: ruby
+# Cookbook Name:: ruby_compile
 # Attribute:: default
 #
 
-default[:ruby][:ruby_version]      = '2.1.5'
-default[:ruby][:major_version]     = '2.1'
-default[:ruby][:source][:checksum] = '4305cc6ceb094df55210d83548dcbeb5117d74eea25196a9b14fa268d354b100'
-default[:ruby][:install_gems]      = %w{ bundler }
-default[:ruby][:extra_pkgs]        = []
+default[:ruby_compile][:ruby_version]      = '2.1.5'
+default[:ruby_compile][:major_version]     = '2.1'
+default[:ruby_compile][:source][:checksum] = '4305cc6ceb094df55210d83548dcbeb5117d74eea25196a9b14fa268d354b100'
+default[:ruby_compile][:install_gems]      = %w{ bundler }
+default[:ruby_compile][:extra_pkgs]        = []
 
-default[:ruby][:ruby_file]    = "ruby-#{node[:ruby][:ruby_version]}.tar.gz"
-default[:ruby][:source][:url] = "http://ftp.ruby-lang.org/pub/ruby/#{node[:ruby][:major_version]}/#{node[:ruby][:ruby_file]}"
+default[:ruby_compile][:ruby_file]    = "ruby-#{node[:ruby_compile][:ruby_version]}.tar.gz"
+default[:ruby_compile][:source][:url] = "http://ftp.ruby-lang.org/pub/ruby/#{node[:ruby_compile][:major_version]}/#{node[:ruby_compile][:ruby_file]}"
 
-default[:ruby][:source][:cache_filepath] = Chef::Config[:file_cache_path] || '/tmp'
-default[:ruby][:source][:src_filepath]   = "#{node[:ruby][:source][:cache_filepath]}/#{node[:ruby][:ruby_file]}"
+default[:ruby_compile][:source][:cache_filepath] = Chef::Config[:file_cache_path] || '/tmp'
+default[:ruby_compile][:source][:src_filepath]   = "#{node[:ruby_compile][:source][:cache_filepath]}/#{node[:ruby_compile][:ruby_file]}"
 
-default[:ruby][:ruby_bin] = '/usr/local/bin/ruby'
-default[:ruby][:gem_bin]  = '/usr/local/bin/gem'
-default[:ruby][:gems_dir] = '/usr/local/lib/ruby/gems/2.1.0/gems'
+default[:ruby_compile][:ruby_bin] = '/usr/local/bin/ruby'
+default[:ruby_compile][:gem_bin]  = '/usr/local/bin/gem'
+default[:ruby_compile][:gems_dir] = '/usr/local/lib/ruby/gems/2.1.0/gems'
 
 case node[:platform_family]
 when 'rhel', 'fedora'
-  default[:ruby][:packages] = %w{ openssl-devel readline readline-devel sqlite-devel zlib zlib-devel }
+  default[:ruby_compile][:packages] = %w{ openssl-devel readline readline-devel sqlite-devel zlib zlib-devel }
 when 'debian'
-  default[:ruby][:packages] = %w{
+  default[:ruby_compile][:packages] = %w{
     git-core curl zlib1g-dev zlib1g build-essential libssl-dev
     libreadline-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev
     libxslt1-dev libcurl4-openssl-dev python-software-properties libffi-dev

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,9 +1,9 @@
-name             'ruby'
+name             'ruby_compile'
 maintainer       'Paul Welch'
 maintainer_email 'paul@pwelch.net'
 license          'MIT'
-description      'Installs Ruby'
-long_description 'Installs Ruby'
+description      'Installs/Compiles Ruby'
+long_description 'Installs/Compiles Ruby'
 version          '0.1.0'
 
 supports 'ubuntu'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,6 +1,6 @@
 #
-# Cookbook Name:: ruby
+# Cookbook Name:: ruby_compile
 # Recipe:: default
 #
 
-include_recipe 'ruby::source'
+include_recipe 'ruby_compile::source'

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -1,23 +1,23 @@
 #
-# Cookbook Name:: ruby
+# Cookbook Name:: ruby_compile
 # Recipe:: source
 #
 
-src_url      = node[:ruby][:source][:url]
-src_filepath = node[:ruby][:source][:src_filepath]
+src_url      = node[:ruby_compile][:source][:url]
+src_filepath = node[:ruby_compile][:source][:src_filepath]
 
 # Install package dependencies
-node[:ruby][:packages].each { |pkg| package pkg }
+node[:ruby_compile][:packages].each { |pkg| package pkg }
 
 # Install any extra packages
-node[:ruby][:extra_pkgs].each { |pkg| package pkg } if !node[:ruby][:extra_pkgs].empty?
+node[:ruby_compile][:extra_pkgs].each { |pkg| package pkg } if !node[:ruby_compile][:extra_pkgs].empty?
 
 # Get Ruby Source
 remote_file src_url do
   source   src_url
   path     src_filepath
-  checksum node[:ruby][:source][:checksum]
-  not_if { ::File.exist? node[:ruby][:ruby_bin] }
+  checksum node[:ruby_compile][:source][:checksum]
+  not_if { ::File.exist? node[:ruby_compile][:ruby_bin] }
 end
 
 # Unarchive Ruby Source
@@ -26,7 +26,7 @@ bash 'unarchive_ruby_source' do
   code <<-EOF
     tar zxf #{::File.basename(src_filepath)} -C #{::File.dirname(src_filepath)}
   EOF
-  not_if { ::File.directory?("#{node[:ruby][:source][:cache_filepath]}/ruby-#{node[:ruby][:ruby_version]}") }
+  not_if { ::File.directory?("#{node[:ruby_compile][:source][:cache_filepath]}/ruby-#{node[:ruby_compile][:ruby_version]}") }
 end
 
 # Compile Ruby
@@ -34,17 +34,17 @@ bash 'compile_ruby' do
   cwd ::File.dirname(src_filepath)
   cwd Chef::Config[:file_cache_path]
   code <<-EOF
-    cd ruby-#{node[:ruby][:ruby_version]} &&
+    cd ruby-#{node[:ruby_compile][:ruby_version]} &&
     ./configure &&
     make && make install
   EOF
-  not_if { ::File.exist? node[:ruby][:ruby_bin] }
+  not_if { ::File.exist? node[:ruby_compile][:ruby_bin] }
 end
 
 # Install Gems to System Ruby
-node[:ruby][:install_gems].each do |gem|
+node[:ruby_compile][:install_gems].each do |gem|
   gem_package gem do
-    gem_binary   node[:ruby][:gem_bin]
+    gem_binary   node[:ruby_compile][:gem_bin]
     compile_time false if respond_to?(:compile_time)
     action       :install
   end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,19 +1,19 @@
 #
-# Cookbook Name:: ruby
+# Cookbook Name:: ruby_compile
 # Spec:: default
 #
 
 require 'spec_helper'
 
-describe 'ruby::default' do
+describe 'ruby_compile::default' do
   context 'When all attributes are default, on Ubuntu platform' do
     let(:chef_run) do
-      runner = ChefSpec::ServerRunner.new(:platform => 'ubuntu', :version => '12.04')
+      runner = ChefSpec::ServerRunner.new(:platform => 'ubuntu', :version => '14.04')
       runner.converge(described_recipe)
     end
 
-    it 'includes the ruby::source recipe' do
-      expect(chef_run).to include_recipe('ruby::source')
+    it 'includes the ruby_compile::source recipe' do
+      expect(chef_run).to include_recipe('ruby_compile::source')
     end
   end
 end

--- a/spec/unit/recipes/source_spec.rb
+++ b/spec/unit/recipes/source_spec.rb
@@ -1,14 +1,14 @@
 #
-# Cookbook Name:: ruby
+# Cookbook Name:: ruby_compile
 # Spec:: source
 #
 
 require 'spec_helper'
 
-describe 'ruby::source' do
+describe 'ruby_compile::source' do
   context 'When all attributes are default, on Ubuntu platform' do
     let(:chef_run) do
-      runner = ChefSpec::ServerRunner.new(:platform => 'ubuntu', :version => '12.04')
+      runner = ChefSpec::ServerRunner.new(:platform => 'ubuntu', :version => '14.04')
       runner.converge(described_recipe)
     end
 
@@ -25,10 +25,10 @@ describe 'ruby::source' do
     it 'downloads ruby source code file' do
       allow(::File).to receive(:exist?).and_call_original
       allow(::File).to receive(:exist?).with('/usr/local/bin/ruby').and_return(false)
-      expect(chef_run).to create_remote_file(chef_run.node.ruby.source.url).with(
-        :source   => chef_run.node.ruby.source.url,
-        :path     => chef_run.node.ruby.source.src_filepath,
-        :checksum => chef_run.node.ruby.source.checksum
+      expect(chef_run).to create_remote_file(chef_run.node.ruby_compile.source.url).with(
+        :source   => chef_run.node.ruby_compile.source.url,
+        :path     => chef_run.node.ruby_compile.source.src_filepath,
+        :checksum => chef_run.node.ruby_compile.source.checksum
       )
     end
 


### PR DESCRIPTION
Change the name of the cookbook from ruby to ruby_compile. This
reflects what it does as well as avoiding naming issues.
