### PR TITLE
Update Ruby Version and Testing

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,6 +8,10 @@ driver_config:
 provisioner:
   name: chef_zero
 
+verifier:
+  name: inspec
+  format: documentation
+
 platforms:
 - name: ubuntu-12.04
   driver_config:
@@ -19,5 +23,5 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[ruby::default]
+      - recipe[ruby_compile::default]
     attributes:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,7 +26,10 @@ Style/PercentLiteralDelimiters:
   Enabled: false
 
 # Don't fail on whitespace between method names and arguments
-Style/SingleSpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
+  Enabled: false
+
+Style/SpaceInsidePercentLiteralDelimiters:
   Enabled: false
 
 Style/NegatedIf:

--- a/Gemfile
+++ b/Gemfile
@@ -6,17 +6,17 @@ group :development do
 end
 
 group :unit do
-  gem 'berkshelf'
-  gem 'chefspec', '~> 4.2'
-  gem 'strainer'
+  gem 'berkshelf', '~> 4.0'
+  gem 'chefspec', '~> 5.0'
 end
 
 group :integration do
   gem 'test-kitchen'
-  gem 'kitchen-vagrant', '~> 0.11'
+  gem 'kitchen-vagrant', '~> 0.20'
+  gem 'kitchen-inspec'
 end
 
 group :lint do
   gem 'foodcritic'
-  gem 'rubocop', '~> 0.28.0'
+  gem 'rubocop', '~> 0.42.0'
 end

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ include_recipe 'ruby_compile::default'
 
 Changing Ruby Version:
 ```ruby
-node.default[:ruby_compile][:ruby_version]      = '2.2.1'
-node.default[:ruby_compile][:major_version]     = '2.2'
-node.default[:ruby_compile][:source][:checksum] = '5a4de38068eca8919cb087d338c0c2e3d72c9382c804fb27ab746e6c7819ab28'
+node.default[:ruby_compile][:ruby_version]      = '2.3.1'
+node.default[:ruby_compile][:major_version]     = '2.3'
+node.default[:ruby_compile][:source][:checksum] = 'b87c738cb2032bf4920fef8e3864dc5cf8eae9d89d8d523ce0236945c5797dcd'
 node.default[:ruby_compile][:install_gems]      = %w{ bundler }
 node.default[:ruby_compile][:extra_pkgs]        = []
 ```

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,9 +4,9 @@
 # Attribute:: default
 #
 
-default[:ruby_compile][:ruby_version]      = '2.1.5'
-default[:ruby_compile][:major_version]     = '2.1'
-default[:ruby_compile][:source][:checksum] = '4305cc6ceb094df55210d83548dcbeb5117d74eea25196a9b14fa268d354b100'
+default[:ruby_compile][:ruby_version]      = '2.3.1'
+default[:ruby_compile][:major_version]     = '2.3'
+default[:ruby_compile][:source][:checksum] = 'b87c738cb2032bf4920fef8e3864dc5cf8eae9d89d8d523ce0236945c5797dcd'
 default[:ruby_compile][:install_gems]      = %w{ bundler }
 default[:ruby_compile][:extra_pkgs]        = []
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,9 +1,12 @@
 name             'ruby_compile'
 maintainer       'Paul Welch'
-maintainer_email 'paul@pwelch.net'
+maintainer_email 'git@pwelch.net'
 license          'MIT'
 description      'Installs/Compiles Ruby'
 long_description 'Installs/Compiles Ruby'
-version          '0.1.0'
+version          '0.1.1'
+
+source_url 'https://github.com/pwelch/chef-ruby_compile'
+issues_url 'https://github.com/pwelch/chef-ruby_compile/issues'
 
 supports 'ubuntu'

--- a/spec/unit/recipes/source_spec.rb
+++ b/spec/unit/recipes/source_spec.rb
@@ -7,7 +7,7 @@ require 'spec_helper'
 
 describe 'ruby_compile::source' do
   context 'When all attributes are default, on Ubuntu platform' do
-    let(:chef_run) do
+    cached(:chef_run) do
       runner = ChefSpec::ServerRunner.new(:platform => 'ubuntu', :version => '14.04')
       runner.converge(described_recipe)
     end
@@ -25,10 +25,10 @@ describe 'ruby_compile::source' do
     it 'downloads ruby source code file' do
       allow(::File).to receive(:exist?).and_call_original
       allow(::File).to receive(:exist?).with('/usr/local/bin/ruby').and_return(false)
-      expect(chef_run).to create_remote_file(chef_run.node.ruby_compile.source.url).with(
-        :source   => chef_run.node.ruby_compile.source.url,
-        :path     => chef_run.node.ruby_compile.source.src_filepath,
-        :checksum => chef_run.node.ruby_compile.source.checksum
+      expect(chef_run).to create_remote_file(chef_run.node[:ruby_compile][:source][:url]).with(
+        :source   => chef_run.node[:ruby_compile][:source][:url],
+        :path     => chef_run.node[:ruby_compile][:source][:src_filepath],
+        :checksum => chef_run.node[:ruby_compile][:source][:checksum]
       )
     end
 

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -1,0 +1,6 @@
+# Inspec examples can be found at
+# https://docs.chef.io/inspec.html
+
+describe file('/usr/local/bin/ruby') do
+  it { should be_file }
+end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,9 +1,0 @@
-require 'spec_helper'
-
-# Serverspec examples can be found at
-# http://serverspec.org/resource_types.html
-describe 'ruby::default' do
-  describe file('/usr/local/bin/ruby') do
-    it { should be_file }
-  end
-end

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -1,3 +1,0 @@
-require 'serverspec'
-
-set :backend, :exec


### PR DESCRIPTION
- Update Ruby version to latest (2.3.1)
- Switch to InSpec for integration tests
- Fix ChefSpec for Chef 13 deprecation warnings with node access (dont
  use node.attribute.foo)
  -
